### PR TITLE
netstandard 1.3 update

### DIFF
--- a/sample/ApiUsage/ApiUsage.csproj
+++ b/sample/ApiUsage/ApiUsage.csproj
@@ -34,13 +34,31 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
-    <Reference Include="System.Core" />
-    <Reference Include="System.Xml.Linq" />
-    <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />
-    <Reference Include="System.Data" />
-    <Reference Include="System.Net.Http" />
-    <Reference Include="System.Xml" />
+    <Reference Include="System.Buffers, Version=4.0.1.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Buffers.4.3.0\lib\netstandard1.1\System.Buffers.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Diagnostics.DiagnosticSource, Version=4.0.1.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Diagnostics.DiagnosticSource.4.3.0\lib\net46\System.Diagnostics.DiagnosticSource.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Net.Http, Version=4.1.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Net.Http.4.3.0\lib\net46\System.Net.Http.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Security.Cryptography.Algorithms, Version=4.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Security.Cryptography.Algorithms.4.3.0\lib\net461\System.Security.Cryptography.Algorithms.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Security.Cryptography.Encoding, Version=4.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Security.Cryptography.Encoding.4.3.0\lib\net46\System.Security.Cryptography.Encoding.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Security.Cryptography.Primitives, Version=4.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Security.Cryptography.Primitives.4.3.0\lib\net46\System.Security.Cryptography.Primitives.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Security.Cryptography.X509Certificates, Version=4.1.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Security.Cryptography.X509Certificates.4.3.0\lib\net461\System.Security.Cryptography.X509Certificates.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Threading.Thread, Version=4.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Threading.Thread.4.3.0\lib\net46\System.Threading.Thread.dll</HintPath>
+    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Program.cs" />
@@ -48,6 +66,7 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="App.config" />
+    <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\Zipkin\Zipkin.csproj">

--- a/sample/ApiUsage/packages.config
+++ b/sample/ApiUsage/packages.config
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="System.Buffers" version="4.3.0" targetFramework="net461" />
+  <package id="System.Diagnostics.DiagnosticSource" version="4.3.0" targetFramework="net461" />
+  <package id="System.Net.Http" version="4.3.0" targetFramework="net461" />
+  <package id="System.Security.Cryptography.Algorithms" version="4.3.0" targetFramework="net461" />
+  <package id="System.Security.Cryptography.Encoding" version="4.3.0" targetFramework="net461" />
+  <package id="System.Security.Cryptography.Primitives" version="4.3.0" targetFramework="net461" />
+  <package id="System.Security.Cryptography.X509Certificates" version="4.3.0" targetFramework="net461" />
+  <package id="System.Threading.Thread" version="4.3.0" targetFramework="net461" />
+</packages>

--- a/src/Zipkin/AsyncRecorder.cs
+++ b/src/Zipkin/AsyncRecorder.cs
@@ -4,6 +4,7 @@ namespace Zipkin
 	using System.Collections.Concurrent;
 	using System.Collections.Generic;
 	using System.Threading;
+	using System.Threading.Tasks;
 
 	public class AsyncRecorder : Recorder
 	{

--- a/src/Zipkin/Codecs/Thrift/Transports/TFramedTransport.cs
+++ b/src/Zipkin/Codecs/Thrift/Transports/TFramedTransport.cs
@@ -51,16 +51,19 @@
 		{
 			// if (!IsOpen)
 			//		throw new TTransportException(TTransportException.ExceptionType.NotOpen);
+			System.ArraySegment<byte> buf;
 
-			byte[] buf = _writeBuffer.GetBuffer();
-			int frameSize = (int) _writeBuffer.Position;
+			if (_writeBuffer.TryGetBuffer(out buf))
+			{
+				int frameSize = (int)_writeBuffer.Position;
 
-			WriteFrameSizeToInnerTransport(frameSize);
-			
-			// Send the entire message at once
-			_innerTransport.Write(buf, 0, frameSize);
+				WriteFrameSizeToInnerTransport(frameSize);
 
-			_innerTransport.Flush();
+				// Send the entire message at once
+				_innerTransport.Write(buf.Array, 0, frameSize);
+
+				_innerTransport.Flush();
+			}
 		}
 
 		protected override void Dispose(bool disposing)
@@ -76,8 +79,12 @@
 			// _readBuffer.Seek(0, SeekOrigin.Begin);
 			_readBuffer.Position = 0;
 
-			byte[] buff = _readBuffer.GetBuffer();
-			_innerTransport.ReadAll(buff, 0, size);
+			System.ArraySegment<byte> buf;
+
+			if (_readBuffer.TryGetBuffer(out buf))
+			{
+				_innerTransport.ReadAll(buf.Array, 0, size);
+			}
 		}
 
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/src/Zipkin/Codecs/Thrift/TypeSystem/TApplicationException.cs
+++ b/src/Zipkin/Codecs/Thrift/TypeSystem/TApplicationException.cs
@@ -1,10 +1,7 @@
 namespace Zipkin.Codecs.Thrift.TypeSystem
 {
 	using System;
-	using System.Runtime.Serialization;
 
-
-	[Serializable]
 	public class TApplicationException : TException
 	{
 		protected ExceptionType type;
@@ -21,10 +18,6 @@ namespace Zipkin.Codecs.Thrift.TypeSystem
 		public TApplicationException(ExceptionType type, string message) : base(message)
 		{
 			this.type = type;
-		}
-
-		protected TApplicationException(SerializationInfo info, StreamingContext context) : base(info, context)
-		{
 		}
 
 		public static TApplicationException Read(ThriftProtocol iprot)

--- a/src/Zipkin/Codecs/Thrift/TypeSystem/TException.cs
+++ b/src/Zipkin/Codecs/Thrift/TypeSystem/TException.cs
@@ -1,9 +1,6 @@
 ﻿namespace Zipkin.Codecs.Thrift.TypeSystem
 {
 	using System;
-	using System.Runtime.Serialization;
-
-	[Serializable]
 	public class TException : Exception
 	{
 		public TException()
@@ -11,10 +8,6 @@
 		}
 
 		public TException(string message) : base(message)
-		{
-		}
-
-		protected TException(SerializationInfo info, StreamingContext context) : base(info, context)
 		{
 		}
 	}

--- a/src/Zipkin/Codecs/Thrift/TypeSystem/TProtocolException.cs
+++ b/src/Zipkin/Codecs/Thrift/TypeSystem/TProtocolException.cs
@@ -1,9 +1,7 @@
 ﻿namespace Zipkin.Codecs.Thrift.TypeSystem
 {
 	using System;
-	using System.Runtime.Serialization;
 
-	[Serializable]
 	public class TProtocolException : TException
 	{
 		public const int UNKNOWN = 0;
@@ -31,10 +29,6 @@
 		}
 
 		public TProtocolException(string message) : base(message)
-		{
-		}
-
-		protected TProtocolException(SerializationInfo info, StreamingContext context) : base(info, context)
 		{
 		}
 

--- a/src/Zipkin/Codecs/Thrift/TypeSystem/TTransportException.cs
+++ b/src/Zipkin/Codecs/Thrift/TypeSystem/TTransportException.cs
@@ -1,9 +1,7 @@
 ﻿namespace Zipkin.Codecs.Thrift.TypeSystem
 {
 	using System;
-	using System.Runtime.Serialization;
 
-	[Serializable]
 	public class TTransportException : TException
 	{
 		protected ExceptionType type;
@@ -23,10 +21,6 @@
 		}
 
 		public TTransportException(string message) : base(message)
-		{
-		}
-
-		protected TTransportException(SerializationInfo info, StreamingContext context) : base(info, context)
 		{
 		}
 

--- a/src/Zipkin/Properties/AssemblyInfo.cs
+++ b/src/Zipkin/Properties/AssemblyInfo.cs
@@ -5,12 +5,7 @@ using System.Runtime.InteropServices;
 // General Information about an assembly is controlled through the following 
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
-[assembly: AssemblyTitle("Zipkin")]
-[assembly: AssemblyDescription("")]
-[assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCompany("")]
-[assembly: AssemblyProduct("Zipkin")]
-[assembly: AssemblyCopyright("Copyright ©  2016")]
+[assembly: AssemblyCopyright("Copyright ©  2017")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 
@@ -22,18 +17,6 @@ using System.Runtime.InteropServices;
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("97b93c51-406b-44b4-864e-21e131622e5a")]
 
-// Version information for an assembly consists of the following four values:
-//
-//      Major Version
-//      Minor Version 
-//      Build Number
-//      Revision
-//
-// You can specify all the values or you can default the Build and Revision Numbers 
-// by using the '*' as shown below:
-// [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]
 
 [assembly: InternalsVisibleTo("Zipkin.Tests")]
 

--- a/src/Zipkin/ScribeSpanDispatcher.cs
+++ b/src/Zipkin/ScribeSpanDispatcher.cs
@@ -40,7 +40,7 @@ namespace Zipkin
 			{
 				NoDelay = true
 			};
-			_tcpClient.Connect(hostname, port);
+			_tcpClient.ConnectAsync(hostname, port).RunSynchronously();
 
 			_frame = new TFramedTransport(new TTcpClientTransport(_tcpClient));
 			_scribeService = new ScribeService(new ThriftProtocol(_frame));
@@ -88,7 +88,16 @@ namespace Zipkin
 			[MethodImpl(MethodImplOptions.AggressiveInlining)]
 			private static string ToBase64(MemoryStream stream)
 			{
-				return Convert.ToBase64String(stream.GetBuffer(), 0, (int)stream.Length);
+				ArraySegment<byte> buffer;
+
+				if (stream.TryGetBuffer(out buffer))
+				{
+					return Convert.ToBase64String(buffer.Array, 0, (int)stream.Length);
+				}
+				else
+				{
+					return string.Empty;
+				}
 			}
 		}
 	}

--- a/src/Zipkin/Zipkin.csproj
+++ b/src/Zipkin/Zipkin.csproj
@@ -1,120 +1,17 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
   <PropertyGroup>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProjectGuid>{97B93C51-406B-44B4-864E-21E131622E5A}</ProjectGuid>
-    <OutputType>Library</OutputType>
-    <AppDesignerFolder>Properties</AppDesignerFolder>
-    <RootNamespace>Zipkin</RootNamespace>
-    <AssemblyName>Zipkin</AssemblyName>
-    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
-    <FileAlignment>512</FileAlignment>
+    <TargetFramework>netstandard1.3</TargetFramework>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <DebugSymbols>true</DebugSymbols>
-    <DebugType>full</DebugType>
-    <Optimize>false</Optimize>
-    <OutputPath>bin\Debug\</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-    <NoWarn>0659,0661,1591</NoWarn>
-    <DocumentationFile>bin\Debug\Zipkin.XML</DocumentationFile>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <DebugType>pdbonly</DebugType>
-    <Optimize>true</Optimize>
-    <OutputPath>bin\Release\</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-    <NoWarn>0659,0661,1591</NoWarn>
-    <DocumentationFile>bin\Release\Zipkin.XML</DocumentationFile>
-  </PropertyGroup>
+
   <ItemGroup>
-    <Reference Include="System" />
-    <Reference Include="System.Buffers, Version=4.0.1.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\System.Buffers.4.3.0\lib\netstandard1.1\System.Buffers.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="System.Configuration" />
-    <Reference Include="System.Core" />
-    <Reference Include="System.Xml.Linq" />
-    <Reference Include="System.Data.DataSetExtensions" />
-    <Reference Include="Microsoft.CSharp" />
-    <Reference Include="System.Data" />
-    <Reference Include="System.Net.Http" />
-    <Reference Include="System.Xml" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="1.1.0" />
+    <PackageReference Include="System.Buffers" Version="4.3.0" />
+    <PackageReference Include="System.Threading.Thread" Version="4.3.0" />
   </ItemGroup>
+
   <ItemGroup>
-    <Compile Include="AsyncRecorder.cs" />
-    <Compile Include="Codecs\Codec.cs" />
-    <Compile Include="Codecs\Thrift\ModelSerializer\AnnotationSerializer.cs" />
-    <Compile Include="Codecs\Thrift\ModelSerializer\BinaryAnnotationSerializer.cs" />
-    <Compile Include="Codecs\Thrift\ModelSerializer\EndpointSerializer.cs" />
-    <Compile Include="Codecs\DateTimeOffsetExtensions.cs" />
-    <Compile Include="Codecs\JsonCodec.cs" />
-    <Compile Include="Codecs\Thrift\ModelSerializer\SpanSerializer.cs" />
-    <Compile Include="Codecs\Thrift\Scribe\ResultCode.cs" />
-    <Compile Include="Codecs\Thrift\Scribe\LogEntry.cs" />
-    <Compile Include="Codecs\Thrift\Scribe\LogEntrySerializer.cs" />
-    <Compile Include="Codecs\Thrift\Scribe\ScribeService.cs" />
-    <Compile Include="Codecs\Thrift\Transports\TFramedTransport.cs" />
-    <Compile Include="Codecs\Thrift\ThriftProtocol.cs" />
-    <Compile Include="Codecs\Thrift\ThriftProtocol.Write.cs" />
-    <Compile Include="Codecs\Thrift\ThriftProtocol.Read.cs" />
-    <Compile Include="Codecs\Thrift\Transports\TTcpClientTransport.cs" />
-    <Compile Include="Codecs\Thrift\Transports\TStreamTransport.cs" />
-    <Compile Include="Codecs\Thrift\Transports\TTransport.cs" />
-    <Compile Include="Codecs\Thrift\TypeSystem\TApplicationException.cs" />
-    <Compile Include="Codecs\Thrift\TypeSystem\TException.cs" />
-    <Compile Include="Codecs\Thrift\TypeSystem\TMessage.cs" />
-    <Compile Include="Codecs\Thrift\TypeSystem\TProtocolException.cs" />
-    <Compile Include="Codecs\Thrift\TypeSystem\TTransportException.cs" />
-    <Compile Include="Codecs\Thrift\TypeSystem\TType.cs" />
-    <Compile Include="Codecs\Thrift\TypeSystem\TField.cs" />
-    <Compile Include="Codecs\Thrift\TypeSystem\TList.cs" />
-    <Compile Include="Codecs\Thrift\TypeSystem\TMap.cs" />
-    <Compile Include="Codecs\Thrift\TypeSystem\TStruct.cs" />
-    <Compile Include="Tracers\TickClock.cs" />
-    <Compile Include="Tracers\StartClientOrContinueTrace.cs" />
-    <Compile Include="Tracers\TraceAnnotate.cs" />
-    <Compile Include="ZipkinBootstrapper.cs" />
-    <Compile Include="Model\Annotation.cs" />
-    <Compile Include="Model\StandardAnnotationKeys.cs" />
-    <Compile Include="Model\AnnotationType.cs" />
-    <Compile Include="Model\BinaryAnnotation.cs" />
-    <Compile Include="Tracers\ITrace.cs" />
-    <Compile Include="Tracers\PredefinedTag.cs" />
-    <Compile Include="Tracers\TraceExtensions.cs" />
-    <Compile Include="RandomHelper.cs" />
-    <Compile Include="Recorder.cs" />
-    <Compile Include="Model\Endpoint.cs" />
-    <Compile Include="Properties\AssemblyInfo.cs" />
-    <Compile Include="Model\Span.cs" />
-    <Compile Include="RecorderMetrics.cs" />
-    <Compile Include="RestSpanDispatcher.cs" />
-    <Compile Include="ScribeSpanDispatcher.cs" />
-    <Compile Include="SpanDispatcher.cs" />
-    <Compile Include="Tracers\StartServerTrace.cs" />
-    <Compile Include="Tracers\LocalTrace.cs" />
-    <Compile Include="TraceContextPropagation.cs" />
-    <Compile Include="Model\CustomAnnotationKeys.cs" />
-    <Compile Include="Codecs\Json\StreamWriterExtensions.cs" />
-    <Compile Include="Codecs\ThriftCodec.cs" />
-    <Compile Include="Tracers\StartClientTrace.cs" />
+    <PackageReference Update="NETStandard.Library" Version="1.6.1" />
   </ItemGroup>
-  <ItemGroup>
-    <None Include="packages.config" />
-  </ItemGroup>
-  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
-       Other similar extension points exist, see Microsoft.Common.targets.
-  <Target Name="BeforeBuild">
-  </Target>
-  <Target Name="AfterBuild">
-  </Target>
-  -->
+
 </Project>

--- a/src/Zipkin/ZipkinBootstrapper.cs
+++ b/src/Zipkin/ZipkinBootstrapper.cs
@@ -1,7 +1,7 @@
 namespace Zipkin
 {
+	using Microsoft.Extensions.Configuration;
 	using System;
-	using System.Configuration;
 	using System.Globalization;
 	using System.Net;
 	using System.Runtime.CompilerServices;
@@ -62,10 +62,12 @@ namespace Zipkin
 			//< add key="ZipkinServerName"  value="localhost" />
 			//< add key="ZipkinSampleRate"  value="0.5" />
 			//< add key="ZipkinServiceName" value="pit" />
+			var builder = new ConfigurationBuilder();
+			var config = builder.Build();
 
-			var serviceName = ConfigurationManager.AppSettings["ZipkinServiceName"];
-			var sampleRate = double.Parse(ConfigurationManager.AppSettings["ZipkinSampleRate"] ?? "0.0", CultureInfo.InvariantCulture);
-			var zipkinServer = ConfigurationManager.AppSettings["ZipkinServerName"];
+			var serviceName = config["ZipkinServiceName"];
+			var sampleRate = double.Parse(config["ZipkinSampleRate"] ?? "0.0", CultureInfo.InvariantCulture);
+			var zipkinServer = config["ZipkinServerName"];
 
 			if (serviceName == null)  throw new Exception("Missing configuration entry: 'ZipkinServiceName' under appsettings, which should define this service's name");
 			if (zipkinServer == null) throw new Exception("Missing configuration entry: 'ZipkinServerName' under appsettings, which should point to zipkin server's hostname");

--- a/src/Zipkin/packages.config
+++ b/src/Zipkin/packages.config
@@ -1,4 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="System.Buffers" version="4.3.0" targetFramework="net461" />
-</packages>

--- a/tests/Zipkin.Tests/Zipkin.Tests.csproj
+++ b/tests/Zipkin.Tests/Zipkin.Tests.csproj
@@ -30,26 +30,25 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="FluentAssertions, Version=4.14.0.0, Culture=neutral, PublicKeyToken=33f2691a05b67b6a, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\FluentAssertions.4.14.0\lib\net45\FluentAssertions.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="FluentAssertions, Version=4.19.0.0, Culture=neutral, PublicKeyToken=33f2691a05b67b6a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\FluentAssertions.4.19.0\lib\net45\FluentAssertions.dll</HintPath>
     </Reference>
-    <Reference Include="FluentAssertions.Core, Version=4.14.0.0, Culture=neutral, PublicKeyToken=33f2691a05b67b6a, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\FluentAssertions.4.14.0\lib\net45\FluentAssertions.Core.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="FluentAssertions.Core, Version=4.19.0.0, Culture=neutral, PublicKeyToken=33f2691a05b67b6a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\FluentAssertions.4.19.0\lib\net45\FluentAssertions.Core.dll</HintPath>
     </Reference>
-    <Reference Include="nunit.framework, Version=2.6.4.14350, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\NUnit.2.6.4\lib\nunit.framework.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="nunit.framework, Version=3.6.0.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\NUnit.3.6.0\lib\net45\nunit.framework.dll</HintPath>
     </Reference>
     <Reference Include="System" />
-    <Reference Include="System.Core" />
-    <Reference Include="System.Xml.Linq" />
-    <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />
-    <Reference Include="System.Data" />
-    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Threading.Thread, Version=4.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Threading.Thread.4.3.0\lib\net46\System.Threading.Thread.dll</HintPath>
+    </Reference>
     <Reference Include="System.Xml" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Xml.XmlDocument, Version=4.0.2.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Xml.XmlDocument.4.3.0\lib\net46\System.Xml.XmlDocument.dll</HintPath>
+    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="AsyncRecorderTest.cs" />
@@ -76,7 +75,11 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
+    <None Include="app.config" />
     <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/tests/Zipkin.Tests/app.config
+++ b/tests/Zipkin.Tests/app.config
@@ -1,12 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
-    <startup> 
-        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.1" />
-    </startup>
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
-        <assemblyIdentity name="System.Diagnostics.DiagnosticSource" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <assemblyIdentity name="System.Threading.Thread" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-4.0.1.0" newVersion="4.0.1.0" />
       </dependentAssembly>
     </assemblyBinding>

--- a/tests/Zipkin.Tests/packages.config
+++ b/tests/Zipkin.Tests/packages.config
@@ -1,5 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="FluentAssertions" version="4.14.0" targetFramework="net461" />
-  <package id="NUnit" version="2.6.4" targetFramework="net461" />
+  <package id="FluentAssertions" version="4.19.0" targetFramework="net461" />
+  <package id="NUnit" version="3.6.0" targetFramework="net461" />
+  <package id="System.Threading.Thread" version="4.3.0" targetFramework="net461" />
+  <package id="System.Xml.XDocument" version="4.3.0" targetFramework="net461" />
+  <package id="System.Xml.XmlDocument" version="4.3.0" targetFramework="net461" />
 </packages>


### PR DESCRIPTION
This should allow it to run cross platform on .net 4.6+ or .NET Core.  You will need VS2017 RC to be able to compile the Zipkin project since its in the new csproj format instead of the project.json or xproj.

I kept the Zipkin.Tests and Client at .net 4.6.1 to test out that it worked.  

There were two awkward things that you end up doing for .net 4.x projects:
1. Add the following nuget packages
```
System.Buffers
System.Net.Http
System.Threading.Thread
```
2. Potentially add assembly remappings to go after the new versions (see the Zipkin.Tests\app.config)
```
<?xml version="1.0" encoding="utf-8"?>
<configuration>
  <runtime>
    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
      <dependentAssembly>
        <assemblyIdentity name="System.Threading.Thread" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
        <bindingRedirect oldVersion="0.0.0.0-4.0.1.0" newVersion="4.0.1.0" />
      </dependentAssembly>
    </assemblyBinding>
  </runtime>
</configuration>
```