### PR TITLE
Target net46 and NetStandard1.3

### DIFF
--- a/src/Zipkin/Zipkin.csproj
+++ b/src/Zipkin/Zipkin.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard1.3</TargetFramework>
+    <TargetFrameworks>netstandard1.3;net46</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='ReleaseNet46|AnyCPU'">
@@ -9,14 +9,13 @@
     <OutputPath>bin\ReleaseNet46\net46\</OutputPath>
   </PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="1.1.0" />
-    <PackageReference Include="System.Buffers" Version="4.3.0" />
+  <ItemGroup Condition="'$(TargetFramework)'=='netstandard1.3'">
     <PackageReference Include="System.Threading.Thread" Version="4.3.0" />
-  </ItemGroup>
-
-  <ItemGroup>
     <PackageReference Update="NETStandard.Library" Version="1.6.1" />
   </ItemGroup>
 
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="1.1.0" />
+    <PackageReference Include="System.Buffers" Version="4.3.0" />
+  </ItemGroup>
 </Project>


### PR DESCRIPTION
Hi,

I rewrote your project to target both **NetStandard1.3** and **Net46** that allow you to produce a package containing those versions which have different dependencies.

With the command `dotnet pack -c Release` you obtain 

![image](https://user-images.githubusercontent.com/3425823/28540609-3f7e0bd6-70b6-11e7-89f0-f4887cb4da02.png)

I noticed that your [current package](https://www.nuget.org/packages/Zipkin/1.0.13) target **NetStandard1.4** and not **NetStandard1.3**, is any reason to this ?

Regards,

kévin